### PR TITLE
FOV based fading

### DIFF
--- a/lua/psi/client/cl_main.lua
+++ b/lua/psi/client/cl_main.lua
@@ -20,9 +20,6 @@ Convar.cl_enabled = Convar.new("Client enabled", nil, "cl_enabled", "1", FCVAR_A
 -- Privacy Mode
 Convar.privacy_mode = Convar.new("Privacy mode", nil, "privacy_mode", "0", FCVAR_ARCHIVE, "Only report AFK status to other players")
 
--- Render Distance
-Convar.render_distance = Convar.new("Render distance", nil, "render_distance", "280", FCVAR_ARCHIVE, "Set the max rendering distance of icons (source units)", 100, 800)
-
 -- Height Offset
 Convar.height_offset = Convar.new("Height offset", nil, "height_offset", "15", FCVAR_ARCHIVE, "Set the overhead offset distance of icons (source units)", 15, 30)
 

--- a/lua/psi/client/scripts/status_visualization.lua
+++ b/lua/psi/client/scripts/status_visualization.lua
@@ -129,6 +129,8 @@ local function Render(bdepth, bskybox)
 
 	if bskybox then return end -- Current call is drawing skybox, not good for us
 
+	local height_offset = Convar.height_offset[Enum.HANDLE]:GetFloat()
+
 	for ply, statusinfo in pairs(Statuses) do
 
 		-- Disconnect hook is not reliable
@@ -153,11 +155,7 @@ local function Render(bdepth, bskybox)
 			base_pos = (ply:LocalToWorld(ply:OBBCenter()) + ply:GetUp() * 24)
 		end
 
-		local render_pos = base_pos + ply:GetUp() * Convar.height_offset[Enum.HANDLE]:GetFloat()
-
-		-- Distance fading
-		local render_mindist = Convar.render_distance[Enum.HANDLE]:GetFloat()
-		local render_maxdist = render_mindist + fade_dist_window
+		local render_pos = base_pos + ply:GetUp() * height_offset
 
 		local dist = render_pos:Distance(EyePos())
 		local dist_clamped = math.Clamp(dist, render_mindist, render_maxdist) -- Needs to be clamped, otherwise math.Remap goes out of bounds

--- a/lua/psi/client/scripts/status_visualization.lua
+++ b/lua/psi/client/scripts/status_visualization.lua
@@ -23,6 +23,7 @@ local Statuses = PSI.Statuses
 local render_scale = 0.05
 
 local icon_size = 115
+local icon_real_size = icon_size * render_scale
 
 local icon_max_alpha = 200
 -- Colors used for rendering icon and text
@@ -30,7 +31,10 @@ local icon_max_alpha = 200
 local fade_white = Color(255, 255, 255)
 local fade_black = Color(0, 0, 0)
 
-local fade_dist_window = 80 -- Source units
+-- How much of the view does the icon have to take up to appear fully visible
+local fading_ratio_max = 1.1 / 100
+-- The ratio at which the icon starts appearing
+local fading_ratio_min = fading_ratio_max * 0.7
 
 local timestamp_offset = 95
 local timestamp_font = "PSI_Timestamp"
@@ -129,6 +133,9 @@ local function Render(bdepth, bskybox)
 
 	if bskybox then return end -- Current call is drawing skybox, not good for us
 
+	-- https://developer.valvesoftware.com/wiki/Field_of_View
+	local object_scale = 1 / (2 * (math.tan(math.rad(LocalPlayer():GetFOV() / 2))))
+
 	local height_offset = Convar.height_offset[Enum.HANDLE]:GetFloat()
 
 	for ply, statusinfo in pairs(Statuses) do
@@ -157,9 +164,11 @@ local function Render(bdepth, bskybox)
 
 		local render_pos = base_pos + ply:GetUp() * height_offset
 
+		-- Fading
 		local dist = render_pos:Distance(EyePos())
-		local dist_clamped = math.Clamp(dist, render_mindist, render_maxdist) -- Needs to be clamped, otherwise math.Remap goes out of bounds
-		local dist_alpha = math.Remap(dist_clamped, render_mindist, render_maxdist, icon_max_alpha, 0)
+		local icon_view_ratio = object_scale * icon_real_size / dist
+		local icon_view_ratio_clamped = math.Clamp(icon_view_ratio, fading_ratio_min, fading_ratio_max)
+		local dist_alpha = math.Remap(icon_view_ratio_clamped, fading_ratio_min, fading_ratio_max, 0, icon_max_alpha)
 
 		if dist_alpha == 0 then goto next end -- Nothing to render
 

--- a/lua/psi/client/scripts/ui.lua
+++ b/lua/psi/client/scripts/ui.lua
@@ -61,7 +61,6 @@ local function MakeSettingsMenu(panel)
 			checkbox:SetEnabled(active)
 		end
 
-		Convar.render_distance[Enum.PANEL]:SetEnabled(active)
 		Convar.height_offset[Enum.PANEL]:SetEnabled(active)
 
 	end
@@ -115,12 +114,6 @@ local function MakeSettingsMenu(panel)
 		end
 
 	end
-
-	-- Render distance
-
-	local slider_render_distance = panel:NumSlider(Convar.render_distance[Enum.LABEL], Convar.render_distance:GetName(), Convar.render_distance:GetMin(), Convar.render_distance:GetMax(), 0)
-	slider_render_distance:SetTooltip(Convar.render_distance:GetHelpText())
-	Convar.render_distance[Enum.PANEL] = slider_render_distance
 
 	-- Height offset
 


### PR DESCRIPTION
- Fading effect of icons now takes FOV into account, this makes it possible to zoom on a player using the camera from far away, and see their status
- Render distance setting was removed, as it is no longer needed